### PR TITLE
only use timer start function if timer is at 00:00 (or first loaded)

### DIFF
--- a/src/components/dashboard/timer.js
+++ b/src/components/dashboard/timer.js
@@ -8,7 +8,9 @@ const Timer = () => {
   const [time, start] = React.useContext(TimerStore)
 
   React.useEffect(() => {
-    start()
+    if (time === "00:00") {
+      start()
+    }
     // eslint-disable-next-line
   }, [])
 
@@ -16,7 +18,7 @@ const Timer = () => {
     <>
       <div className="timer-container">
         <div className="timer">
-        <img src={Time} alt="" className="time-icon" />
+          <img src={Time} alt="" className="time-icon" />
           <span>
             {time.split(":")[0] >= 10 ? (
               <span style={{ color: "red" }}>{time}</span>
@@ -24,7 +26,6 @@ const Timer = () => {
               <span style={{ color: "black" }}>{time}</span>
             )}
           </span>
-
         </div>
         <p className="timer-msg">This should take 15 minutes</p>
       </div>


### PR DESCRIPTION
A change in the timer package caused it to restart each time the dashboard (with timer) component loads. A check for its state being 00:00 on each timer load will keep the previous timer state as the user progresses - only calling start() on first load.